### PR TITLE
Add trace timecost log for ChainService

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -205,6 +205,7 @@ struct TimeCost {
     db_commit: Duration,
     resolve_block_transactions: Duration,
     non_contextual_block_verifier: Duration,
+    until_non_contextual_block_verifier: Duration,
     contextual_block_verifier: Duration,
     verify_script: Duration,
 }
@@ -408,10 +409,15 @@ impl ChainService {
         }
         // non-contextual verify
         if !switch.disable_non_contextual() {
+            let start_time = std::time::Instant::now();
             self.non_contextual_verify(&block)?;
+            self.time_cost
+                .non_contextual_block_verifier
+                .add_assign(start_time.elapsed());
         }
+
         self.time_cost
-            .non_contextual_block_verifier
+            .until_non_contextual_block_verifier
             .add_assign(start_time.elapsed());
 
         let mut total_difficulty = U256::zero();

--- a/sync/src/synchronizer/block_process.rs
+++ b/sync/src/synchronizer/block_process.rs
@@ -1,5 +1,6 @@
+use crate::synchronizer::TimeCost;
 use crate::{synchronizer::Synchronizer, utils::is_internal_db_error, Status, StatusCode};
-use ckb_logger::debug;
+use ckb_logger::{debug, info};
 use ckb_network::PeerIndex;
 use ckb_types::{packed, prelude::*};
 
@@ -22,13 +23,22 @@ impl<'a> BlockProcess<'a> {
         }
     }
 
-    pub fn execute(self) -> Status {
+    pub fn execute(self, time_cost: &TimeCost) -> Status {
         let block = self.message.block().to_entity().into_view();
         debug!(
             "BlockProcess received block {} {}",
             block.number(),
             block.hash(),
         );
+
+        let block_number = block.number();
+        if block_number == 1 || block_number % 100_000 == 0 {
+            info!(
+                "block:{}, synchronizer: time_cost {:?}",
+                block_number, time_cost
+            );
+        }
+
         let shared = self.synchronizer.shared();
         let state = shared.state();
 


### PR DESCRIPTION
```
no assume:

ubuntu@ckb-0:~/trace_0.110.0_no_assume$ grep time_cost data_dir/data/logs/run.log  | grep "block:1,"
2023-11-02 12:34:24.598 +00:00 ChainService INFO ckb_chain::chain  block:1, time_cost TimeCost { wait_process_block: 133.740144238s, process_block: 0ns, db_commit: 2.314193ms, resolve_block_transactions: 4.187µs, non_contextual_block_verifier: 74.262µs, contextual_block_verifier: 2.097785ms, verify_script: 60.976µs }

ubuntu@ckb-0:~/trace_0.110.0_no_assume$ grep time_cost data_dir/data/logs/run.log  | grep 10000000
2023-11-03 13:02:52.266 +00:00 ChainService INFO ckb_chain::chain  block:10000000, time_cost TimeCost { wait_process_block: 27845.126543862s, process_block: 88227.236892333s, db_commit: 59979.810476131s, resolve_block_transactions: 913.272139826s, non_contextual_block_verifier: 4463.308075922s, contextual_block_verifier: 52972.981170989s, verify_script: 47677.662336674s }

assume:
ubuntu@ckb-1:~/trace_0.110.0_assume$ grep time_cost data_dir/data/logs/run.log  | grep "block:1,"
2023-11-02 14:24:15.581 +00:00 ChainService INFO ckb_chain::chain  block:1, time_cost TimeCost { wait_process_block: 6462.197926647s, process_block: 0ns, db_commit: 214.11569ms, resolve_block_transactions: 9.668024ms, non_contextual_block_verifier: 94.388134ms, contextual_block_verifier: 47.872298ms, verify_script: 3.055024ms }

ubuntu@ckb-1:~/trace_0.110.0_assume$ grep time_cost data_dir/data/logs/run.log  | grep 10000000
2023-11-03 21:01:14.020 +00:00 ChainService INFO ckb_chain::chain  block:10000000, time_cost TimeCost { wait_process_block: 44180.963531719s, process_block: 116667.614114358s, db_commit: 72089.230029289s, resolve_block_transactions: 6328.861791732s, non_contextual_block_verifier: 30462.010335316s, contextual_block_verifier: 38949.41989033s, verify_script: 1546.681209002s }

```