### PR TITLE
Add integration test to check correctly sync after restart

### DIFF
--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -398,6 +398,7 @@ fn all_specs() -> Vec<Box<dyn Spec>> {
         Box::new(BlockSyncNonAncestorBestBlocks),
         Box::new(RequestUnverifiedBlocks),
         Box::new(SyncTimeout),
+        Box::new(SyncChurn),
         Box::new(GetBlockFilterCheckPoints),
         Box::new(GetBlockFilterHashes),
         Box::new(GetBlockFilters),

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -580,6 +580,7 @@ fn all_specs() -> Vec<Box<dyn Spec>> {
         Box::new(CheckVmVersion1),
         Box::new(CheckVmVersion2),
         Box::new(CheckVmBExtension),
+        Box::new(RandomlyKill),
     ];
     specs.shuffle(&mut thread_rng());
     specs

--- a/test/src/net.rs
+++ b/test/src/net.rs
@@ -140,7 +140,7 @@ impl Net {
         let protocol_id = protocol.protocol_id();
         let peer_index = self
             .receivers
-            .get(node_id)
+            .get(&node_id)
             .map(|(peer_index, _)| *peer_index)
             .unwrap_or_else(|| panic!("not connected peer {}", node.p2p_address()));
         self.controller()
@@ -156,7 +156,7 @@ impl Net {
         let node_id = node.node_id();
         let (peer_index, receiver) = self
             .receivers
-            .get(node_id)
+            .get(&node_id)
             .unwrap_or_else(|| panic!("not connected peer {}", node.p2p_address()));
         let net_message = receiver.recv_timeout(timeout)?;
         info!(

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -26,10 +26,11 @@ use std::convert::Into;
 use std::fs;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, RwLock};
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 
-struct ProcessGuard {
+pub(crate) struct ProcessGuard {
     pub name: String,
     pub child: Child,
     pub killed: bool,
@@ -47,7 +48,12 @@ impl Drop for ProcessGuard {
     }
 }
 
+#[derive(Clone)]
 pub struct Node {
+    inner: Arc<InnerNode>,
+}
+
+pub struct InnerNode {
     spec_node_name: String,
     working_dir: PathBuf,
     consensus: Consensus,
@@ -55,8 +61,8 @@ pub struct Node {
     rpc_client: RpcClient,
     rpc_listen: String,
 
-    node_id: Option<String>,     // initialize when starts node
-    guard: Option<ProcessGuard>, // initialize when starts node
+    node_id: RwLock<Option<String>>, // initialize when starts node
+    guard: RwLock<Option<ProcessGuard>>, // initialize when starts node
 }
 
 impl Node {
@@ -106,7 +112,7 @@ impl Node {
         modifier(&mut app_config);
         fs::write(&app_config_path, toml::to_string(&app_config).unwrap()).unwrap();
 
-        *self = Self::init(self.working_dir(), self.spec_node_name.clone());
+        *self = Self::init(self.working_dir(), self.inner.spec_node_name.clone());
     }
 
     pub fn modify_chain_spec<M>(&mut self, modifier: M)
@@ -119,7 +125,7 @@ impl Node {
         modifier(&mut chain_spec);
         fs::write(&chain_spec_path, toml::to_string(&chain_spec).unwrap()).unwrap();
 
-        *self = Self::init(self.working_dir(), self.spec_node_name.clone());
+        *self = Self::init(self.working_dir(), self.inner.spec_node_name.clone());
     }
 
     // Initialize Node instance based on working directory
@@ -151,44 +157,51 @@ impl Node {
             chain_spec.build_consensus().unwrap()
         };
         Self {
-            spec_node_name,
-            working_dir,
-            consensus,
-            p2p_listen,
-            rpc_client,
-            rpc_listen,
-            node_id: None,
-            guard: None,
+            inner: Arc::new(InnerNode {
+                spec_node_name,
+                working_dir,
+                consensus,
+                p2p_listen,
+                rpc_client,
+                rpc_listen,
+                node_id: RwLock::new(None),
+                guard: RwLock::new(None),
+            }),
         }
     }
 
     pub fn rpc_client(&self) -> &RpcClient {
-        &self.rpc_client
+        &self.inner.rpc_client
     }
 
     pub fn working_dir(&self) -> PathBuf {
-        self.working_dir.clone()
+        self.inner.working_dir.clone()
     }
 
     pub fn log_path(&self) -> PathBuf {
         self.working_dir().join("data/logs/run.log")
     }
 
-    pub fn node_id(&self) -> &str {
+    pub fn node_id(&self) -> String {
         // peer_id.to_base58()
-        self.node_id.as_ref().expect("uninitialized node_id")
+        self.inner
+            .node_id
+            .read()
+            .expect("read locked node_id")
+            .clone()
+            .expect("uninitialized node_id")
     }
 
     pub fn consensus(&self) -> &Consensus {
-        &self.consensus
+        &self.inner.consensus
     }
 
     pub fn p2p_listen(&self) -> String {
-        self.p2p_listen.clone()
+        self.inner.p2p_listen.clone()
     }
 
     pub fn rpc_listen(&self) -> String {
-        self.rpc_listen.clone()
+        self.inner.rpc_listen.clone()
     }
 
     pub fn p2p_address(&self) -> String {
@@ -679,21 +692,37 @@ impl Node {
 
         self.wait_tx_pool_ready();
 
-        self.guard = Some(ProcessGuard {
-            name: self.spec_node_name.clone(),
+        self.set_process_guard(ProcessGuard {
+            name: self.inner.spec_node_name.clone(),
             child: child_process,
             killed: false,
         });
-        self.node_id = Some(node_info.node_id);
+        self.set_node_id(node_info.node_id.as_str());
+    }
+
+    pub(crate) fn set_process_guard(&mut self, guard: ProcessGuard) {
+        let mut g = self.inner.guard.write().unwrap();
+        *g = Some(guard);
+    }
+
+    pub(crate) fn set_node_id(&mut self, node_id: &str) {
+        let mut n = self.inner.node_id.write().unwrap();
+        *n = Some(node_id.to_owned());
+    }
+
+    pub(crate) fn take_guard(&mut self) -> Option<ProcessGuard> {
+        let mut g = self.inner.guard.write().unwrap();
+        g.take()
     }
 
     pub fn stop(&mut self) {
-        drop(self.guard.take())
+        drop(self.take_guard());
     }
 
     #[cfg(not(target_os = "windows"))]
     pub fn stop_gracefully(&mut self) {
-        if let Some(mut guard) = self.guard.take() {
+        let guard = self.take_guard();
+        if let Some(mut guard) = guard {
             if !guard.killed {
                 // send SIGINT to the child
                 nix::sys::signal::kill(

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -821,8 +821,8 @@ pub fn make_bootnodes_for_all<N: BorrowMut<Node>>(nodes: &mut [N]) {
         })
         .collect();
     let other_node_addrs: Vec<Vec<Multiaddr>> = node_multiaddrs
-        .iter()
-        .map(|(id, _)| {
+        .keys()
+        .map(|id| {
             let addrs = node_multiaddrs
                 .iter()
                 .filter(|(other_id, _)| other_id.as_str() != id.as_str())

--- a/test/src/node.rs
+++ b/test/src/node.rs
@@ -810,7 +810,6 @@ pub fn waiting_for_sync<N: Borrow<Node>>(nodes: &[N]) {
     }
 }
 
-// TODO it will be removed out later, in another PR
 pub fn make_bootnodes_for_all<N: BorrowMut<Node>>(nodes: &mut [N]) {
     let node_multiaddrs: HashMap<String, Multiaddr> = nodes
         .iter()

--- a/test/src/specs/fault_injection/mod.rs
+++ b/test/src/specs/fault_injection/mod.rs
@@ -1,0 +1,3 @@
+mod randomly_kill;
+
+pub use randomly_kill::*;

--- a/test/src/specs/fault_injection/randomly_kill.rs
+++ b/test/src/specs/fault_injection/randomly_kill.rs
@@ -1,0 +1,31 @@
+use crate::{Node, Spec};
+
+use ckb_logger::info;
+use rand::{thread_rng, Rng};
+
+pub struct RandomlyKill;
+
+impl Spec for RandomlyKill {
+    crate::setup!(num_nodes: 1);
+
+    fn run(&self, nodes: &mut Vec<Node>) {
+        let mut rng = thread_rng();
+        let node = &mut nodes[0];
+        for _ in 0..rng.gen_range(10, 20) {
+            let n = rng.gen_range(0, 10);
+            // TODO: the kill of child process and mining are actually sequential here
+            // We need to find some way to so these two things in parallel.
+            // It would be great if we can kill and start the node externally (instead of writing
+            // rust code to manage all the nodes, because in that case we will have to fight
+            // ownership rules, and monitor node).
+            if n != 0 {
+                info!("Mining {} blocks", n);
+                node.mine(n);
+            }
+            info!("Stop the node");
+            node.stop();
+            info!("Start the node");
+            node.start();
+        }
+    }
+}

--- a/test/src/specs/mod.rs
+++ b/test/src/specs/mod.rs
@@ -8,6 +8,7 @@ mod relay;
 mod rpc;
 mod sync;
 mod tx_pool;
+mod fault_injection;
 
 pub use alert::*;
 pub use consensus::*;
@@ -19,6 +20,7 @@ pub use relay::*;
 pub use rpc::*;
 pub use sync::*;
 pub use tx_pool::*;
+pub use fault_injection::*;
 
 use crate::Node;
 use ckb_app_config::CKBAppConfig;

--- a/test/src/specs/mod.rs
+++ b/test/src/specs/mod.rs
@@ -1,6 +1,7 @@
 mod alert;
 mod consensus;
 mod dao;
+mod fault_injection;
 mod hardfork;
 mod mining;
 mod p2p;
@@ -8,11 +9,11 @@ mod relay;
 mod rpc;
 mod sync;
 mod tx_pool;
-mod fault_injection;
 
 pub use alert::*;
 pub use consensus::*;
 pub use dao::*;
+pub use fault_injection::*;
 pub use hardfork::*;
 pub use mining::*;
 pub use p2p::*;
@@ -20,7 +21,6 @@ pub use relay::*;
 pub use rpc::*;
 pub use sync::*;
 pub use tx_pool::*;
-pub use fault_injection::*;
 
 use crate::Node;
 use ckb_app_config::CKBAppConfig;

--- a/test/src/specs/p2p/whitelist.rs
+++ b/test/src/specs/p2p/whitelist.rs
@@ -49,7 +49,7 @@ impl Spec for WhitelistOnSessionLimit {
             peers.len() == 2
                 && peers
                     .into_iter()
-                    .all(|node| id_set.contains(&node.node_id.as_str()))
+                    .all(|node| id_set.contains(&node.node_id))
         });
 
         if !is_connect_peer_num_eq_2 {
@@ -81,7 +81,7 @@ impl Spec for WhitelistOnSessionLimit {
             peers.len() == 3
                 && peers
                     .into_iter()
-                    .all(|node| id_set.contains(&node.node_id.as_str()))
+                    .all(|node| id_set.contains(&node.node_id))
         });
 
         if !is_connect_peer_num_eq_3 {

--- a/test/src/specs/p2p/whitelist.rs
+++ b/test/src/specs/p2p/whitelist.rs
@@ -46,10 +46,7 @@ impl Spec for WhitelistOnSessionLimit {
         let rpc_client0 = node0.rpc_client();
         let is_connect_peer_num_eq_2 = wait_until(10, || {
             let peers = rpc_client0.get_peers();
-            peers.len() == 2
-                && peers
-                    .into_iter()
-                    .all(|node| id_set.contains(&node.node_id))
+            peers.len() == 2 && peers.into_iter().all(|node| id_set.contains(&node.node_id))
         });
 
         if !is_connect_peer_num_eq_2 {
@@ -78,10 +75,7 @@ impl Spec for WhitelistOnSessionLimit {
         let rpc_client0 = node0.rpc_client();
         let is_connect_peer_num_eq_3 = wait_until(10, || {
             let peers = rpc_client0.get_peers();
-            peers.len() == 3
-                && peers
-                    .into_iter()
-                    .all(|node| id_set.contains(&node.node_id))
+            peers.len() == 3 && peers.into_iter().all(|node| id_set.contains(&node.node_id))
         });
 
         if !is_connect_peer_num_eq_3 {

--- a/test/src/specs/sync/mod.rs
+++ b/test/src/specs/sync/mod.rs
@@ -8,6 +8,7 @@ mod invalid_locator_size;
 mod last_common_header;
 mod sync_and_mine;
 mod sync_timeout;
+mod sync_churn;
 
 pub use block_filter::*;
 pub use block_sync::*;
@@ -19,3 +20,4 @@ pub use invalid_locator_size::*;
 pub use last_common_header::*;
 pub use sync_and_mine::*;
 pub use sync_timeout::*;
+pub use sync_churn::*;

--- a/test/src/specs/sync/mod.rs
+++ b/test/src/specs/sync/mod.rs
@@ -7,8 +7,8 @@ mod invalid_block;
 mod invalid_locator_size;
 mod last_common_header;
 mod sync_and_mine;
-mod sync_timeout;
 mod sync_churn;
+mod sync_timeout;
 
 pub use block_filter::*;
 pub use block_sync::*;
@@ -19,5 +19,5 @@ pub use invalid_block::*;
 pub use invalid_locator_size::*;
 pub use last_common_header::*;
 pub use sync_and_mine::*;
-pub use sync_timeout::*;
 pub use sync_churn::*;
+pub use sync_timeout::*;

--- a/test/src/specs/sync/sync_churn.rs
+++ b/test/src/specs/sync/sync_churn.rs
@@ -50,6 +50,6 @@ impl Spec for SyncChurn {
         restart_thread.join().unwrap();
 
         info!("Waiting for all nodes sync");
-        waiting_for_sync(&nodes);
+        waiting_for_sync(nodes);
     }
 }

--- a/test/src/specs/sync/sync_churn.rs
+++ b/test/src/specs/sync/sync_churn.rs
@@ -1,0 +1,40 @@
+use crate::node::{make_bootnodes_for_all, waiting_for_sync};
+use crate::{Node, Spec};
+use ckb_logger::info;
+use rand::Rng;
+
+fn select_random_node<'a, R: Rng>(rng: &mut R, nodes: &'a mut [Node]) -> &'a mut Node {
+    let index = rng.gen_range(0, nodes.len());
+    &mut nodes[index]
+}
+
+fn randomly_restart<R: Rng>(rng: &mut R, restart_probilibity: f64, node: &mut Node) {
+    let should_restart = rng.gen_bool(restart_probilibity);
+    if should_restart {
+        node.stop();
+        node.start();
+    }
+}
+
+pub struct SyncChurn;
+
+impl Spec for SyncChurn {
+    crate::setup!(num_nodes: 5);
+
+    fn run(&self, nodes: &mut Vec<Node>) {
+        make_bootnodes_for_all(nodes);
+
+        let mut rng = rand::thread_rng();
+        let (mining_nodes, churn_nodes) = nodes.split_at_mut(1);
+        for _ in 0..1000 {
+            const RESTART_PROBABILITY: f64 = 0.1;
+            let mining_node = select_random_node(&mut rng, mining_nodes);
+            mining_node.mine(1);
+            let node = select_random_node(&mut rng, churn_nodes);
+            randomly_restart(&mut rng, RESTART_PROBABILITY, node);
+        }
+
+        info!("Waiting for all nodes sync");
+        waiting_for_sync(&nodes);
+    }
+}

--- a/test/src/specs/sync/sync_churn.rs
+++ b/test/src/specs/sync/sync_churn.rs
@@ -12,6 +12,17 @@ fn select_random_node<'a, R: Rng>(rng: &mut R, nodes: &'a mut [Node]) -> &'a mut
 
 pub struct SyncChurn;
 
+/// This test will start 5 nodes, and randomly restart 4 nodes in the middle of mining.
+/// After all nodes are synced, the test is considered successful.
+/// This test is used to test the robustness of the sync protocol.
+/// If the sync protocol is not robust enough, the test will fail.
+/// But this test is not a complete test, it can only test the robustness of the sync protocol to a certain extent.
+/// Some weaknesses of this test:
+/// 1. This test only consider the simple case of some nodes restarting in the middle of mining,
+/// while other nodes are always mining correctly.
+/// 2. This fault injection of restarting nodes is not comprehensive enough.
+/// 3. Even if the test fails, we can't deterministically reproduce the same error.
+/// We may need some foundationdb-like tools to deterministically reproduce the same error.
 impl Spec for SyncChurn {
     crate::setup!(num_nodes: 5);
 

--- a/test/src/specs/sync/sync_churn.rs
+++ b/test/src/specs/sync/sync_churn.rs
@@ -1,4 +1,5 @@
 use crate::node::{make_bootnodes_for_all, waiting_for_sync};
+use crate::util::mining::out_ibd_mode;
 use crate::{Node, Spec};
 use ckb_logger::info;
 use rand::Rng;
@@ -28,9 +29,10 @@ impl Spec for SyncChurn {
 
     fn run(&self, nodes: &mut Vec<Node>) {
         make_bootnodes_for_all(nodes);
+        out_ibd_mode(nodes);
 
         let mut mining_nodes = nodes.clone();
-        let mut churn_nodes = mining_nodes.split_off(1);
+        let mut churn_nodes = mining_nodes.split_off(2);
 
         let (restart_stopped_tx, restart_stopped_rx) = mpsc::channel();
 


### PR DESCRIPTION
Add an integration test for randomly kill node and then check if it can still sync. Since we need a separate thread a control the killing and restart behavior of the node, I also made the `Node` data struct `Send` and `Clone` able here.